### PR TITLE
add install instruction of portaudio for macOS env

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Activate the virtual environment:
 pip install -r requirements.txt
 ```
 
+> [!NOTE] To install pyaudio in macOS environment, please install `portaudio` first.
+``` bash
+xcode-select --install
+brew install portaudio
+```
+
 ### 4. Install Ollama
 
 If you haven't already installed Ollama, follow the instructions at [Ollama's official website](https://ollama.ai/download).


### PR DESCRIPTION
Thank you for sharing this great work!

In the macOS environment, installing `portaudio` is required before installing the `pyaudio` package.
If not, the installation command `pip install -r requirements.txt` may result in errors on the `pyaudio` stage.

Thus, I suggest including additional install instruction of `portaudio` on the part "3. Install required Python packages".
Please check this pull request and merge it into the main branch.

Thank you very much!